### PR TITLE
Compiled templates are wrapped in a single require statement

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -42,7 +42,10 @@ module.exports = function (grunt) {
 			// strip template root option
 			exportAMD: {
 				files: {
-					'tmp/out-exportAMD.compiled.js': 'test/fixtures/helloWorld.handlebars'
+					'tmp/out-exportAMD.compiled.js': [
+	                    'test/fixtures/helloWorld.handlebars', 
+	                    'test/fixtures/helloWorldTwo.handlebars'
+	                ] 
 				},
 				options: {
 					exportAMD: true

--- a/tasks/handlebars.js
+++ b/tasks/handlebars.js
@@ -147,12 +147,9 @@ module.exports = function(grunt) {
 
 				templates.push(compiled);
 			});
-			if (templates.length < 1) {
-				grunt.log.warn('Destination not written because there was no output.');
-			} else {
-				templates = templates.join(grunt.util.normalizelf(options.separator));
+			
+			templates = templates.join(grunt.util.normalizelf(options.separator));
 
-			}
 			var wrappedTemplates = prefix + midfix + templates + suffix;
 
 			output = partials.concat(wrappedTemplates);

--- a/test/expected/helloWorld-exportAMD.compiled.js
+++ b/test/expected/helloWorld-exportAMD.compiled.js
@@ -17,4 +17,22 @@ helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
     + "</div>\n	</body>\n</html>";
   return buffer;
   });
+
+templates['helloWorldTwo'] = template(function (Handlebars,depth0,helpers,partials,data) {
+  this.compilerInfo = [4,'>= 1.0.0'];
+helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
+  var buffer = "", stack1, functionType="function", escapeExpression=this.escapeExpression;
+
+
+  buffer += "<!doctype ";
+  if (stack1 = helpers.doctype) { stack1 = stack1.call(depth0, {hash:{},data:data}); }
+  else { stack1 = (depth0 && depth0.doctype); stack1 = typeof stack1 === functionType ? stack1.call(depth0, {hash:{},data:data}) : stack1; }
+  buffer += escapeExpression(stack1)
+    + ">\n<html>\n	<body>\n		<div>Hello world once more! ";
+  if (stack1 = helpers.message) { stack1 = stack1.call(depth0, {hash:{},data:data}); }
+  else { stack1 = (depth0 && depth0.message); stack1 = typeof stack1 === functionType ? stack1.call(depth0, {hash:{},data:data}) : stack1; }
+  buffer += escapeExpression(stack1)
+    + "</div>\n	</body>\n</html>";
+  return buffer;
+  });
 });

--- a/test/fixtures/helloWorldTwo.handlebars
+++ b/test/fixtures/helloWorldTwo.handlebars
@@ -1,0 +1,6 @@
+<!doctype {{doctype}}>
+<html>
+	<body>
+		<div>Hello world once more! {{message}}</div>
+	</body>
+</html>


### PR DESCRIPTION
Hi! I'm using this plugin with the exportAMD option. It worked great for a single template, but when compiling multiple templates into a single file, I ran into issues. The compiled file was wrapping each template in it's own require statement. So it looked something like:

```
define(['handlebars'], function (Handlebars) {
    templates['templateOne'] = template(function (Handlebars,depth0,helpers,partials,data) {
        ...
    }
}
define(['handlebars'], function (Handlebars) {
    templates['templateTwo'] = template(function (Handlebars,depth0,helpers,partials,data) {
        ...
    }
}
```

I believe the issue is caused by the modules not having names but being in the same file, which doesn't play nicely in require. Since all the templates just need to require Handlebars, I rearranged the code a bit so that it generates something more like:

```
define(['handlebars'], function (Handlebars) {
    templates['templateOne'] = template(function (Handlebars,depth0,helpers,partials,data) {
        ...
    }
    templates['templateTwo'] = template(function (Handlebars,depth0,helpers,partials,data) {
        ...
    }
}
```

This works perfectly in my app, and I've updated the AMD tests to use multiple files. I would love to hear your thoughts, though!
