### PR TITLE
Make namespace optional

### DIFF
--- a/tasks/handlebars.js
+++ b/tasks/handlebars.js
@@ -71,7 +71,7 @@ module.exports = function (grunt) {
 		}
 
 		// decide template midfix
-		midfix = 'var template = Handlebars.template, templates = ' + options.namespace + ' = ' + options.namespace + ' || {};\n';
+		midfix = 'var template = Handlebars.template, templates = ' + (options.namespace ? options.namespace + ' = ' + options.namespace + ' || {}' : '{}') + ';\n';
 
 		// assign filename processing (this decides template name under namespace)
 		processFilename = options.processFilename || defaultProcessFilename;


### PR DESCRIPTION
Using your build task in a RequireJS environment and would prefer not to use a namespace to store templates